### PR TITLE
Merge LootHistory Component into Main

### DIFF
--- a/sc-epgp-ui/src/components/UI/LootHistory.jsx
+++ b/sc-epgp-ui/src/components/UI/LootHistory.jsx
@@ -49,7 +49,7 @@ export default function LootHistory() {
 
         {/* If raid dates exist, and the array of raidDates is more than 0, then load the date chooser */}
         {raidDates && raidDates.length > 0 && (
-          <div className='flex flex-row space-x-3 min-w-fit text-[12px] font-bold bg-navBarBg p-[4px] rounded-lg'>
+          <div className='flex flex-row space-x-3 min-w-fit text-[12px] font-bold border-2 border-secondary p-[4px] rounded-lg'>
             {/* If page reaches the last index of the raid dates array, hide it*/}
             {page + 1 === raidDates.length ? null : (
               <button className='text-secondary text-2xl' onClick={() => setPage((prevValue) => prevValue + 1)}>

--- a/sc-epgp-ui/src/components/UI/LootHistory.jsx
+++ b/sc-epgp-ui/src/components/UI/LootHistory.jsx
@@ -3,6 +3,7 @@ import useSWR from 'swr';
 import { useEffect, useState } from 'react';
 import { epgpApi } from '../../../config.json';
 import { getClassColor } from '../../utils/getClassColor';
+import { BsFillArrowLeftSquareFill, BsFillArrowRightSquareFill } from 'react-icons/bs';
 
 const LOOTHISTORY_API_ENDPOINT = `${epgpApi.baseUrl}/Loot/date/paged/`;
 const fetcher = (url) => axios.get(url).then((res) => res.data);
@@ -19,7 +20,6 @@ export default function LootHistory() {
   useEffect(() => {
     // Refresh the wowhead links so they render properly
     $WowheadPower.refreshLinks();
-
     // Pull the raidDates from the api into raidDates
     if (data) {
       const unformattedDates = data.raidDates;
@@ -31,32 +31,47 @@ export default function LootHistory() {
           year: 'numeric',
         });
       });
-
       setRaidDates(formattedDates);
     }
-
-    console.log(page);
-    console.log(raidDates.length);
-  }, [data, setRaidDates, page]);
+  }, [data, setRaidDates]);
 
   // Divs depending on conditions
   if (error) return <div>Failed to load data</div>;
-  if (!data) return <div>Loading...</div>;
 
   return (
-    <>
-      <div className='flex flex-col w-full h-full font-poppins'>
-        <h2 className='font-black text-4xl h-[70px]'>Loot History</h2>
-        <div>
-          {/* If page reaches the last index of the raid dates array, hide it*/}
-          {page + 1 === raidDates.length ? null : <button onClick={() => setPage((prevValue) => prevValue + 1)}>⬅️</button>}
+    <div className='flex flex-col w-full h-full font-poppins'>
+      <div className='h-[70px] w-full space-y-1'>
+        {/* Default renders */}
+        <h2 className='font-black text-4xl'>Loot History</h2>
 
-          <span>{raidDates[page]}</span>
+        {/* If there's an error, load an error div */}
+        {error && <div>Failed to load data.</div>}
 
-          {/* If page is set to zero, do not show the right button */}
-          {page === 0 ? null : <button onClick={() => setPage((prevValue) => prevValue - 1)}>➡️</button>}
-        </div>
-        <div className='space-y-1 font-poppins'>
+        {/* If raid dates exist, and the array of raidDates is more than 0, then load the date chooser */}
+        {raidDates && raidDates.length > 0 && (
+          <div className='flex flex-row space-x-3 w-fit text-[12px] font-bold'>
+            {/* If page reaches the last index of the raid dates array, hide it*/}
+            {page + 1 === raidDates.length ? null : (
+              <button className='text-secondary' onClick={() => setPage((prevValue) => prevValue + 1)}>
+                <BsFillArrowLeftSquareFill />
+              </button>
+            )}
+            <span className='text-center'>{raidDates[page]}</span>
+            {/* If page is set to zero, do not show the right button */}
+            {page === 0 ? null : (
+              <button className='text-secondary' onClick={() => setPage((prevValue) => prevValue - 1)}>
+                <BsFillArrowRightSquareFill />
+              </button>
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* While loading, show a loading div for the loot history list only */}
+      {!data && <div className='flex-grow'>Loading data...</div>}
+
+      {data && (
+        <div className='font-poppins divide-y-[2px] divide-secondary/50'>
           {data.lootHistory.loot
             // filter out any elements in the array that have duplicate characterName and itemString.itemId properties
             .filter((el, index, self) => self.findIndex((t) => t.characterName === el.characterName && t.itemString.itemId === el.itemString.itemId) === index)
@@ -67,11 +82,9 @@ export default function LootHistory() {
               const classColor = getClassColor(el.characterClass);
 
               return (
-                <div className='py-1 text-sm'>
+                <div className='py-2 text-[12px]'>
                   <span style={{ color: classColor }}>{charName}</span>
-                  <span> </span>
-                  <span>looted</span>
-                  <span> </span>
+                  <span> looted </span>
                   <a
                     className='font-bold'
                     data-wowhead={'bonus=' + item.bonusIds.join(':').replace(/\s+/g, '')}
@@ -83,7 +96,7 @@ export default function LootHistory() {
               );
             })}
         </div>
-      </div>
-    </>
+      )}
+    </div>
   );
 }

--- a/sc-epgp-ui/src/components/UI/LootHistory.jsx
+++ b/sc-epgp-ui/src/components/UI/LootHistory.jsx
@@ -44,7 +44,7 @@ export default function LootHistory() {
     { 'invisible disabled': page + 1 === raidDates.length }, // apply if inactive
   ]);
 
-  // -- For the left arrow, If page reaches the last index of the raid dates array, hide it
+  // -- For the right arrow, If page is zero, hide it.
   const rightArrowBtnStyle = classNames([
     { 'text-secondary text-2xl': page !== 0 }, // apply if active
     { 'invisible disabled': page === 0 }, // apply if inactive

--- a/sc-epgp-ui/src/components/UI/LootHistory.jsx
+++ b/sc-epgp-ui/src/components/UI/LootHistory.jsx
@@ -4,6 +4,8 @@ import { useEffect, useState } from 'react';
 import { epgpApi } from '../../../config.json';
 import { getClassColor } from '../../utils/getClassColor';
 import { BsFillArrowLeftSquareFill, BsFillArrowRightSquareFill } from 'react-icons/bs';
+import classNames from 'classnames';
+import { Link } from 'react-router-dom';
 
 const LOOTHISTORY_API_ENDPOINT = `${epgpApi.baseUrl}/Loot/date/paged/`;
 const fetcher = (url) => axios.get(url).then((res) => res.data);
@@ -35,6 +37,19 @@ export default function LootHistory() {
     }
   }, [data, setRaidDates]);
 
+  // Styles for the buttons in the date picker
+  // -- For the left arrow, If page reaches the last index of the raid dates array, hide it
+  const leftArrowBtnStyle = classNames([
+    { 'text-secondary text-2xl': !(page + 1 === raidDates.length) }, // apply if active
+    { 'invisible disabled': page + 1 === raidDates.length }, // apply if inactive
+  ]);
+
+  // -- For the left arrow, If page reaches the last index of the raid dates array, hide it
+  const rightArrowBtnStyle = classNames([
+    { 'text-secondary text-2xl': page !== 0 }, // apply if active
+    { 'invisible disabled': page === 0 }, // apply if inactive
+  ]);
+
   // Divs depending on conditions
   if (error) return <div>Failed to load data</div>;
 
@@ -50,19 +65,17 @@ export default function LootHistory() {
         {/* If raid dates exist, and the array of raidDates is more than 0, then load the date chooser */}
         {raidDates && raidDates.length > 0 && (
           <div className='flex flex-row space-x-3 min-w-fit text-[12px] font-bold border-2 border-secondary p-[4px] rounded-lg'>
-            {/* If page reaches the last index of the raid dates array, hide it*/}
-            {page + 1 === raidDates.length ? null : (
-              <button className='text-secondary text-2xl' onClick={() => setPage((prevValue) => prevValue + 1)}>
-                <BsFillArrowLeftSquareFill />
-              </button>
-            )}
+            {/* Left Button */}
+            <button className={leftArrowBtnStyle} onClick={() => setPage((prevValue) => prevValue + 1)}>
+              <BsFillArrowLeftSquareFill />
+            </button>
+            {/* Date Text */}
             <span className='text-center place-self-center flex-grow'>{raidDates[page]}</span>
-            {/* If page is set to zero, do not show the right button */}
-            {page === 0 ? null : (
-              <button className='text-secondary text-2xl' onClick={() => setPage((prevValue) => prevValue - 1)}>
-                <BsFillArrowRightSquareFill />
-              </button>
-            )}
+            {/* Right Button */}
+
+            <button className={rightArrowBtnStyle} onClick={() => setPage((prevValue) => prevValue - 1)}>
+              <BsFillArrowRightSquareFill />
+            </button>
           </div>
         )}
         {data && (
@@ -75,12 +88,16 @@ export default function LootHistory() {
               .map((el) => {
                 // destructuring assignment
                 const charName = el.characterName;
+                const realm = el.realm;
+                const region = el.region;
                 const item = el.itemString;
                 const classColor = getClassColor(el.characterClass);
 
                 return (
                   <div className='py-2 text-[12px]'>
-                    <span style={{ color: classColor }}>{charName}</span>
+                    <Link to={`/characters/${region}/${realm}/${charName}`}>
+                      <span style={{ color: classColor }}>{charName}</span>
+                    </Link>
                     <span> looted </span>
                     <a
                       className='font-bold'
@@ -97,7 +114,11 @@ export default function LootHistory() {
       </div>
 
       {/* While loading, show a loading div for the loot history list only */}
-      {!data && <div className='flex-grow'>Loading data...</div>}
+      {!data && (
+        <div className='bg-secondary/10 h-full rounded-xl flex place-items-center justify-center items-center'>
+          <div className='spinner-border animate-spin inline-block w-12 h-12 border-8 rounded-full text-secondary' role='status'></div>
+        </div>
+      )}
     </div>
   );
 }

--- a/sc-epgp-ui/src/components/UI/LootHistory.jsx
+++ b/sc-epgp-ui/src/components/UI/LootHistory.jsx
@@ -1,7 +1,89 @@
+import axios from 'axios';
+import useSWR from 'swr';
+import { useEffect, useState } from 'react';
+import { epgpApi } from '../../../config.json';
+import { getClassColor } from '../../utils/getClassColor';
+
+const LOOTHISTORY_API_ENDPOINT = `${epgpApi.baseUrl}/Loot/date/paged/`;
+const fetcher = (url) => axios.get(url).then((res) => res.data);
+
 export default function LootHistory() {
+  // States
+  const [page, setPage] = useState(0);
+  const [raidDates, setRaidDates] = useState([]);
+
+  // SWRfetch
+  const { data, error } = useSWR(LOOTHISTORY_API_ENDPOINT + page, fetcher);
+
+  // UseEffects
+  useEffect(() => {
+    // Refresh the wowhead links so they render properly
+    $WowheadPower.refreshLinks();
+
+    // Pull the raidDates from the api into raidDates
+    if (data) {
+      const unformattedDates = data.raidDates;
+      const formattedDates = unformattedDates.map((d) => {
+        const date = new Date(d);
+        return date.toLocaleDateString('en-US', {
+          month: 'long',
+          day: 'numeric',
+          year: 'numeric',
+        });
+      });
+
+      setRaidDates(formattedDates);
+    }
+
+    console.log(page);
+    console.log(raidDates.length);
+  }, [data, setRaidDates, page]);
+
+  // Divs depending on conditions
+  if (error) return <div>Failed to load data</div>;
+  if (!data) return <div>Loading...</div>;
+
   return (
-    <div className='flex flex-col w-full bg-test1 h-full'>
-      <h2 className='font-poppins font-black text-4xl '>Loot History</h2>
-    </div>
+    <>
+      <div className='flex flex-col w-full h-full font-poppins'>
+        <h2 className='font-black text-4xl h-[70px]'>Loot History</h2>
+        <div>
+          {/* If page reaches the last index of the raid dates array, hide it*/}
+          {page + 1 === raidDates.length ? null : <button onClick={() => setPage((prevValue) => prevValue + 1)}>⬅️</button>}
+
+          <span>{raidDates[page]}</span>
+
+          {/* If page is set to zero, do not show the right button */}
+          {page === 0 ? null : <button onClick={() => setPage((prevValue) => prevValue - 1)}>➡️</button>}
+        </div>
+        <div className='space-y-1 font-poppins'>
+          {data.lootHistory.loot
+            // filter out any elements in the array that have duplicate characterName and itemString.itemId properties
+            .filter((el, index, self) => self.findIndex((t) => t.characterName === el.characterName && t.itemString.itemId === el.itemString.itemId) === index)
+            .map((el) => {
+              // destructuring assignment
+              const charName = el.characterName;
+              const item = el.itemString;
+              const classColor = getClassColor(el.characterClass);
+
+              return (
+                <div className='py-1 text-sm'>
+                  <span style={{ color: classColor }}>{charName}</span>
+                  <span> </span>
+                  <span>looted</span>
+                  <span> </span>
+                  <a
+                    className='font-bold'
+                    data-wowhead={'bonus=' + item.bonusIds.join(':').replace(/\s+/g, '')}
+                    href={`https://www.wowhead.com/item=${item.itemId}`}
+                  >
+                    {item.itemId}
+                  </a>
+                </div>
+              );
+            })}
+        </div>
+      </div>
+    </>
   );
 }

--- a/sc-epgp-ui/src/components/UI/LootHistory.jsx
+++ b/sc-epgp-ui/src/components/UI/LootHistory.jsx
@@ -40,7 +40,7 @@ export default function LootHistory() {
 
   return (
     <div className='flex flex-col w-full h-full font-poppins'>
-      <div className='h-[70px] w-full space-y-1'>
+      <div className='w-full space-y-2'>
         {/* Default renders */}
         <h2 className='font-black text-4xl'>Loot History</h2>
 
@@ -49,54 +49,55 @@ export default function LootHistory() {
 
         {/* If raid dates exist, and the array of raidDates is more than 0, then load the date chooser */}
         {raidDates && raidDates.length > 0 && (
-          <div className='flex flex-row space-x-3 w-fit text-[12px] font-bold'>
+          <div className='flex flex-row space-x-3 min-w-fit text-[12px] font-bold bg-navBarBg p-[4px] rounded-lg'>
             {/* If page reaches the last index of the raid dates array, hide it*/}
             {page + 1 === raidDates.length ? null : (
-              <button className='text-secondary' onClick={() => setPage((prevValue) => prevValue + 1)}>
+              <button className='text-secondary text-2xl' onClick={() => setPage((prevValue) => prevValue + 1)}>
                 <BsFillArrowLeftSquareFill />
               </button>
             )}
-            <span className='text-center'>{raidDates[page]}</span>
+            <span className='text-center place-self-center flex-grow'>{raidDates[page]}</span>
             {/* If page is set to zero, do not show the right button */}
             {page === 0 ? null : (
-              <button className='text-secondary' onClick={() => setPage((prevValue) => prevValue - 1)}>
+              <button className='text-secondary text-2xl' onClick={() => setPage((prevValue) => prevValue - 1)}>
                 <BsFillArrowRightSquareFill />
               </button>
             )}
+          </div>
+        )}
+        {data && (
+          <div className='font-poppins divide-y-[2px] divide-secondary/50'>
+            {data.lootHistory.loot
+              // filter out any elements in the array that have duplicate characterName and itemString.itemId properties
+              .filter(
+                (el, index, self) => self.findIndex((t) => t.characterName === el.characterName && t.itemString.itemId === el.itemString.itemId) === index
+              )
+              .map((el) => {
+                // destructuring assignment
+                const charName = el.characterName;
+                const item = el.itemString;
+                const classColor = getClassColor(el.characterClass);
+
+                return (
+                  <div className='py-2 text-[12px]'>
+                    <span style={{ color: classColor }}>{charName}</span>
+                    <span> looted </span>
+                    <a
+                      className='font-bold'
+                      data-wowhead={'bonus=' + item.bonusIds.join(':').replace(/\s+/g, '')}
+                      href={`https://www.wowhead.com/item=${item.itemId}`}
+                    >
+                      {item.itemId}
+                    </a>
+                  </div>
+                );
+              })}
           </div>
         )}
       </div>
 
       {/* While loading, show a loading div for the loot history list only */}
       {!data && <div className='flex-grow'>Loading data...</div>}
-
-      {data && (
-        <div className='font-poppins divide-y-[2px] divide-secondary/50'>
-          {data.lootHistory.loot
-            // filter out any elements in the array that have duplicate characterName and itemString.itemId properties
-            .filter((el, index, self) => self.findIndex((t) => t.characterName === el.characterName && t.itemString.itemId === el.itemString.itemId) === index)
-            .map((el) => {
-              // destructuring assignment
-              const charName = el.characterName;
-              const item = el.itemString;
-              const classColor = getClassColor(el.characterClass);
-
-              return (
-                <div className='py-2 text-[12px]'>
-                  <span style={{ color: classColor }}>{charName}</span>
-                  <span> looted </span>
-                  <a
-                    className='font-bold'
-                    data-wowhead={'bonus=' + item.bonusIds.join(':').replace(/\s+/g, '')}
-                    href={`https://www.wowhead.com/item=${item.itemId}`}
-                  >
-                    {item.itemId}
-                  </a>
-                </div>
-              );
-            })}
-        </div>
-      )}
     </div>
   );
 }

--- a/sc-epgp-ui/src/components/UI/Table.jsx
+++ b/sc-epgp-ui/src/components/UI/Table.jsx
@@ -148,11 +148,12 @@ export default function Table() {
             </div>
           ) : null}
         </div>
+        {/* Selection Filters */}
         <Context.Provider value={{ filters, setFilters }}>
           <LootTypeSelect />
         </Context.Provider>
       </div>
-      {/* Search Bar and Filters */}
+      {/* Search Bar */}
       <div className='flex justify-center place-items-center'>
         <GlobalFilter filter={globalFilter} setFilter={setGlobalFilter} />
       </div>

--- a/sc-epgp-ui/src/pages/home/Home.jsx
+++ b/sc-epgp-ui/src/pages/home/Home.jsx
@@ -5,10 +5,10 @@ export default function Home() {
   return (
     <div className='flex-grow sm:flex sm:flex-row sm:space-x-5'>
       {/* Change 'sm:w-full' to 'sm:w-4/6 once Loot History API is up' */}
-      <div className='flex flex-col mx-auto space-y-3 w-fit sm:w-full'>{<Table />}</div>
-      {/* <div className='sm:w-2/6'>
+      <div className='flex flex-col mx-auto space-y-3 w-fit sm:w-4/6'>{<Table />}</div>
+      <div className='sm:w-2/6'>
         <LootHistory />
-      </div> */}
+      </div>
     </div>
   );
 }

--- a/sc-epgp-ui/src/pages/home/Home.jsx
+++ b/sc-epgp-ui/src/pages/home/Home.jsx
@@ -3,10 +3,10 @@ import LootHistory from '../../components/UI/LootHistory';
 
 export default function Home() {
   return (
-    <div className='flex-grow sm:flex sm:flex-row sm:space-x-5'>
+    <div className='flex-grow sm:flex sm:flex-row sm:space-x-8 sm:space-y-0 space-y-8 '>
       {/* Change 'sm:w-full' to 'sm:w-4/6 once Loot History API is up' */}
-      <div className='flex flex-col mx-auto space-y-3 w-fit sm:w-4/6'>{<Table />}</div>
-      <div className='sm:w-2/6'>
+      <div className='flex flex-col mx-auto space-y-3 w-full sm:w-4/6'>{<Table />}</div>
+      <div className='flex flex-col mx-auto space-y-3 w-full sm:w-2/6'>
         <LootHistory />
       </div>
     </div>

--- a/sc-epgp-ui/tailwind.config.cjs
+++ b/sc-epgp-ui/tailwind.config.cjs
@@ -20,10 +20,6 @@ module.exports = {
       green: '#22c55e',
       red: '#ef4444',
       navBarBg: '#1B2D6E',
-      // class colors
-      DeathKnight: '#C41E3A',
-      DemonHunter: '#A330C9',
-      Mage: '#3FC7EB',
     },
     extend: {
       fontFamily: {


### PR DESCRIPTION
The home page now has a loot history component:

- You can now select the raid date and a list of players looting their respective items will now show
- Buttons have been added to navigate between dates, and will go invisible depending on the index of the total raidDates array.
- You can also click on the player name which will take you to the specific player's loot history page.

I think we're finally done here :)